### PR TITLE
adding test report generation by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [flake8]
 exclude = docs
+
+[tool:pytest]
+addopts = --junitxml=test-reports/test.xml


### PR DESCRIPTION
was trying to figure out why the tests weren't generating test reports -- this was it.